### PR TITLE
Add a new, optional, PID match to the header.

### DIFF
--- a/filter-10-header.conf
+++ b/filter-10-header.conf
@@ -1,6 +1,6 @@
 filter {
   grok {
-    match => ["message","\[%{YEAR:year}-%{MONTHNUM:monthnum}-%{MONTHDAY:monthday} %{HOUR:hour}:%{MINUTE:minute}:%{SECOND:second} %{ISO8601_TIMEZONE:timezone}\] %{WORD:[icinga][severity]}/%{WORD:[icinga][facility]}: %{GREEDYDATA:message}"]
+    match => ["message","\[%{YEAR:year}-%{MONTHNUM:monthnum}-%{MONTHDAY:monthday} %{HOUR:hour}:%{MINUTE:minute}:%{SECOND:second} %{ISO8601_TIMEZONE:timezone}\] (\[PID %{POSINT:[process][pid]}\] )?%{WORD:[icinga][severity]}/%{WORD:[icinga][facility]}: %{GREEDYDATA:message}"]
     add_tag => ["icinga2_header"]
     tag_on_failure => ["_grokparsefailure","icinga2_header_failed"]
     id => "icinga2"

--- a/filter-50-pluginchecktask.conf
+++ b/filter-50-pluginchecktask.conf
@@ -2,7 +2,7 @@ filter {
   if [icinga][facility] == "PluginCheckTask" {
     if [message] =~ /^Check command for object/ {
       grok {
-        match => ["message","Check command for object '%{DATA:[icinga][object]}' \(PID: %{POSINT:[process][pid]}, arguments: '%{DATA:[file][path]}' %{DATA:[icinga][pluginarguments]}\) terminated with exit code %{POSINT:[icinga][pluginexitcode]}, output: %{GREEDYDATA:[icinga][pluginoutput]}"]
+        match => ["message","Check command for object '%{DATA:[icinga][object]}' \(PID: %{POSINT:[icinga][pid]}, arguments: '%{DATA:[file][path]}' %{DATA:[icinga][pluginarguments]}\) terminated with exit code %{POSINT:[icinga][pluginexitcode]}, output: %{GREEDYDATA:[icinga][pluginoutput]}"]
         id => "icinga_checkcommandforobject"
         add_tag => "icinga_checkcommandforobject"
         tag_on_failure => ["_grokparsefailure","icinga_checkcommandforobject_failed"]

--- a/filter-50-process.conf
+++ b/filter-50-process.conf
@@ -2,7 +2,7 @@ filter {
   if [icinga][facility] == "Process" {
     if [message] =~ /^PID/ {
       grok {
-        match => ["message","PID %{POSINT:[process][pid]} (\(%{DATA:[icinga][command]}\) )?(was )?terminated (by signal %{NUMBER:[icinga][signalcode]} \(%{WORD:[icinga][signaldetail]}\)|with exit code %{NUMBER:[icinga][exitcode]})"]
+        match => ["message","PID %{POSINT:[icinga][pid]} (\(%{DATA:[icinga][command]}\) )?(was )?terminated (by signal %{NUMBER:[icinga][signalcode]} \(%{WORD:[icinga][signaldetail]}\)|with exit code %{NUMBER:[icinga][exitcode]})"]
         id => "icinga_process_pidterminated"
         add_tag => "icinga_process_pidterminated"
         tag_on_failure => ["_grokparsefailure","icinga_process_pidterminated_failed"]
@@ -12,7 +12,7 @@ filter {
       }
     } else if [message] =~ /^Running command/ {
       grok {
-        match => ["message","Running command %{DATA:[icinga][command]}: PID %{POSINT:[process][pid]}"]
+        match => ["message","Running command %{DATA:[icinga][command]}: PID %{POSINT:[icinga][pid]}"]
         id => "icinga_runningcommand"
         add_tag => "icinga_runningcommand"
         tag_on_failure => ["_grokparsefailure","icinga_runningcommand_failed"]


### PR DESCRIPTION
This is needed because Icinga plans on changing their log format in https://github.com/Icinga/icinga2/pull/7872

Thanks to @dgeotz for pointing that possible issue out.

We already had a `process.pid` in our loglines. This change also renames the already present `process.pid` to `icinga.pid`. Time will tell if this other pid will still be available in loglines.

fixes #52